### PR TITLE
Add vault design iterations

### DIFF
--- a/brainstorm/architecture.md
+++ b/brainstorm/architecture.md
@@ -1,0 +1,51 @@
+# Vault High Level Architecture
+
+This document sketches the major components for a secure, read-only registry called **Vault**.
+
+## Overview
+
+- **Purpose**: Provide a canonical store for schemas, generated code, skeletons, and potentially secrets. The role of secrets is still under active discussion.
+- **Traits**: Immutable history, versioned artifacts, minimal write surface, strong access controls.
+
+```mermaid
+flowchart TD
+    subgraph Storage
+        Git["Git repos"]
+        S3[(S3/Blob Storage)]
+    end
+    subgraph Vault
+        SchemaSvc["Schema Service"]
+        SecretSvc["Secret Service"]
+        CodeGen["Code Generator"]
+    end
+    Client["Client"]
+
+    Client -->|pull artifacts| Git
+    Client -->|requests| Vault
+    Vault --> Storage
+```
+
+## Component Highlights
+
+- **Schema Service**: Validates and stores versioned schemas.
+- **Secret Service**: Interfaces with KMS or HSM to manage encrypted secrets (may live elsewhere).
+- **Code Generator**: Provides framework skeletons and generated code artifacts.
+- **Read-Only**: Majority of users only read; writes require elevated privileges and automated pipelines.
+
+The architecture favors a layered approach with clear boundaries:
+
+1. **Storage** – versioned repositories and object stores.
+2. **Domain** – core logic for schema/secret management.
+3. **Interfaces** – CLI or HTTP APIs for retrieval.
+
+## Design Options
+
+1. **Monolithic Vault** – Single repo containing schemas, generated code, project skeletons, and secrets. Simplifies discovery at the cost of mixing responsibilities.
+2. **Vault + Secret Repo** – Core Vault repository for code artifacts; a separate repo dedicated to secret storage. Aligns with Single Responsibility Principle and allows stricter access controls for secrets.
+3. **Service-Oriented** – Minimal repo with schemas only, while code generation and secret management are delivered as independent services. Keeps Vault extremely focused and promotes encapsulation.
+
+## Open Questions
+
+- If secrets move to a different repo, how do we link them back to schema versions?
+- Should code generation be triggered by CI in this repo or externally?
+

--- a/brainstorm/principles.md
+++ b/brainstorm/principles.md
@@ -1,0 +1,17 @@
+# Core Principles
+
+1. **Security First**
+   - Everything is immutable once published.
+   - If secrets are stored here, they remain encrypted using a centralized KMS.
+
+2. **Domain Driven Design**
+   - Clear bounded contexts: Schema and CodeGen are mandatory; Secret management is optional and may be split out.
+   - Each module exposes interfaces but hides implementation details.
+
+3. **Automation**
+   - All writes flow through CI/CD pipelines with auditing.
+   - Consumers pull artifacts via CLI or minimal HTTP endpoints.
+
+4. **Versioned Artifacts**
+   - Semantic versioning ensures compatibility tracking.
+   - Deprecation policies encourage cleanup and updates.

--- a/brainstorm/repo_structure.md
+++ b/brainstorm/repo_structure.md
@@ -1,0 +1,34 @@
+# Proposed Repository Layout
+
+Option A – **Monolithic**
+```
+/ (project root)
+│
+├── schemas/          # JSON/YAML schema definitions
+├── codegen/          # Generated libraries and utilities
+├── skeletons/        # Starter project templates
+├── secrets/          # Encrypted secrets and API keys
+├── docs/             # Design docs and usage guides
+└── tools/            # Helper scripts for management
+```
+Includes everything in one place but mixes concerns.
+
+Option B – **Split Secrets**
+```
+/ (project root)
+│
+├── schemas/
+├── codegen/
+├── skeletons/
+├── docs/
+└── tools/
+```
+Secrets would reside in a separate private repository with stricter access.
+
+Option C – **Schema Only**
+```
+/ (project root)
+│
+└── schemas/
+```
+Code generation and secrets become independent services or repositories.

--- a/brainstorm/secret_scope_analysis.md
+++ b/brainstorm/secret_scope_analysis.md
@@ -1,0 +1,28 @@
+# Should Vault Own Secrets?
+
+This document evaluates whether the Vault repository should include secret management or whether secrets should be handled in a separate system.
+
+## Context
+Vault currently aims to store schemas, generated code, and project skeletons. Early drafts also included encrypted secrets. Several stakeholders raised concerns about mixing responsibilities.
+
+## Considerations
+
+- **Single Responsibility Principle (SRP)**
+  - Keeping secrets together with schemas introduces a broad surface area.
+  - A dedicated secrets repository could enforce tighter access and auditing.
+
+- **Encapsulation and Security**
+  - Secrets typically require short-lived access and granular permissions.
+  - Schemas and code artifacts are mostly public within the organization.
+  - Splitting secrets enables different review and rotation policies.
+
+- **Operational Complexity**
+  - A combined repo simplifies dependency management but complicates tooling.
+  - Separate repos mean extra orchestration when fetching schemas and secrets.
+
+- **Tradeoffs**
+  - *In Vault*: simpler setup, but potential for privilege creep and larger blast radius.
+  - *Separate Repo*: clearer boundaries and specialized tooling, though more repositories to manage.
+
+## Recommendation
+At staff level, the safer approach is to **separate secrets** from Vault. The Vault repo can focus on immutable artifacts like schemas and generated code, while a dedicated secrets service or repository handles encryption, rotation, and audit requirements. Integration points (e.g., secret references in schemas) should be clearly documented.

--- a/brainstorm/snippets.md
+++ b/brainstorm/snippets.md
@@ -1,0 +1,38 @@
+# Example Snippets
+
+## Schema Definition
+```yaml
+# schemas/user/v1.yaml
+id: User
+properties:
+  id:
+    type: string
+  email:
+    type: string
+    format: email
+  created_at:
+    type: string
+    format: date-time
+required:
+  - id
+  - email
+```
+
+## Python Secret Helper (optional)
+```python
+# tools/secret_helper.py
+import os
+from cryptography.fernet import Fernet
+
+class SecretHelper:
+    def __init__(self, key_env="VAULT_KEY"):
+        key = os.environ[key_env].encode()
+        self.fernet = Fernet(key)
+
+    def decrypt(self, ciphertext: bytes) -> str:
+        return self.fernet.decrypt(ciphertext).decode()
+
+    def encrypt(self, plaintext: str) -> bytes:
+        return self.fernet.encrypt(plaintext.encode())
+```
+This helper might live in a separate secrets repository if Vault decides not to own secret management.

--- a/brainstorm/todo.md
+++ b/brainstorm/todo.md
@@ -1,0 +1,25 @@
+# Project Plan
+
+## 1. Establish Repository
+- [ ] Create initial repo structure as outlined in `repo_structure.md`.
+- [ ] Configure CI/CD for automatic version bumps and artifact storage.
+
+## 2. Implement Schema Service
+- [ ] Decide on storage backend (Git submodule vs. database).
+- [ ] Build validation pipeline to ensure schemas meet standards.
+- [ ] Provide CLI commands for retrieving schema versions.
+
+## 3. Evaluate Secret Management
+- [ ] Decide whether secrets belong in Vault or a separate repository.
+- [ ] If kept here, integrate with enterprise KMS for encryption.
+- [ ] If separated, document integration points and access controls.
+
+## 4. Provide Code Generation Tools
+- [ ] Explore language targets (Python, TypeScript, etc.).
+- [ ] Generate skeletons from schemas and templates.
+
+## 5. Documentation
+- [ ] Write guides describing how to use Vault.
+- [ ] Include architecture diagrams and example snippets.
+
+*These steps can evolve as more requirements become clear.*


### PR DESCRIPTION
## Summary
- expand architecture doc with design options and open questions
- clarify core principles about optional secret management
- provide alternative repo structures
- note optional secret helper snippet
- update project plan to evaluate secret management
- add dedicated staff-level analysis on secrets

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686aa25002a08323bad0e875a52d7277